### PR TITLE
Make rust-lld work correctly under Windows

### DIFF
--- a/example-f429zi-board/.cargo/config
+++ b/example-f429zi-board/.cargo/config
@@ -3,6 +3,7 @@ runner = "arm-none-eabi-gdb -x openocd.gdb"
 rustflags = [
   "-C", "linker=rust-lld",
   "-C", "link-arg=-Tlink.x",
+  "-C", "link-arg=--no-threads",
 ]
 
 [build]


### PR DESCRIPTION
Due to a deadlock in winpthreads, a threading library the rust linker is using on Windows, the build hangs indefinitely during linking phase. Disabling multithreading fixes the issue.