### PR TITLE
Add example for the stm32f407G-DISC1 board

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 members = [
     "example-f401-board",
+    "example-f407-board",
     "example-f429zi-board",
     "example-f446ze-board",
     "example-longan-nano-board",

--- a/example-f407-board/.cargo/config
+++ b/example-f407-board/.cargo/config
@@ -1,0 +1,8 @@
+[target.thumbv7em-none-eabihf]
+runner = "arm-none-eabi-gdb -x openocd.gdb"
+rustflags = [
+  "-C", "link-arg=-Tlink.x",
+]
+
+[build]
+target = "thumbv7em-none-eabihf"

--- a/example-f407-board/Cargo.toml
+++ b/example-f407-board/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "example-f407-board"
+version = "0.1.0"
+authors = ["Vadim Kaushan <admin@disasm.info>", "Johan Kristell <johan@jott.se>"]
+edition = "2018"
+
+[dependencies]
+panic-semihosting = "0.5.2"
+cortex-m-rt = "0.6.10"
+usbd-serial = "0.1.0"
+embedded-hal = "0.2.3"
+stm32f4xx-hal = { version = "0.5.0", features = ["stm32f407", "synopsys-usb-otg", "usb_fs"] }
+usb-device = "0.2.2"

--- a/example-f407-board/README
+++ b/example-f407-board/README
@@ -1,0 +1,1 @@
+For the stm32f407G-DISC1 board

--- a/example-f407-board/build.rs
+++ b/example-f407-board/build.rs
@@ -1,0 +1,15 @@
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Put the linker script somewhere the linker can find it
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    fs::File::create(out_dir.join("memory.x"))
+        .unwrap()
+        .write_all(include_bytes!("memory.x"))
+        .unwrap();
+    println!("cargo:rustc-link-search={}", out_dir.display());
+    println!("cargo:rerun-if-changed=memory.x");
+}

--- a/example-f407-board/examples/enumerate.rs
+++ b/example-f407-board/examples/enumerate.rs
@@ -1,0 +1,50 @@
+#![no_std]
+#![no_main]
+
+extern crate panic_semihosting;
+
+use cortex_m_rt::entry;
+use stm32f4xx_hal::{prelude::*, stm32};
+use stm32f4xx_hal::usb::{Peripheral, UsbBus};
+use usb_device::prelude::*;
+
+static mut EP_MEMORY: [u32; 1024] = [0; 1024];
+
+#[entry]
+fn main() -> ! {
+    let dp = stm32::Peripherals::take().unwrap();
+
+    let rcc = dp.RCC.constrain();
+
+    let _clocks = rcc
+        .cfgr
+        .use_hse(8.mhz())
+        .sysclk(48.mhz())
+        .pclk1(24.mhz())
+        .require_pll48clk()
+        .freeze();
+
+    let gpioa = dp.GPIOA.split();
+
+    let usb = Peripheral {
+        usb_global: dp.OTG_FS_GLOBAL,
+        usb_device: dp.OTG_FS_DEVICE,
+        usb_pwrclk: dp.OTG_FS_PWRCLK,
+        pin_dm: gpioa.pa11.into_alternate_af10(),
+        pin_dp: gpioa.pa12.into_alternate_af10(),
+    };
+
+    let usb_bus = UsbBus::new(usb, unsafe { &mut EP_MEMORY });
+
+    let mut usb_dev = UsbDeviceBuilder::new(&usb_bus, UsbVidPid(0x5824, 0x27dd))
+        .manufacturer("Fake company")
+        .product("Enumeration test")
+        .serial_number("TEST")
+        .device_class(0)
+        .build();
+
+    loop {
+        if usb_dev.poll(&mut []) {
+        }
+    }
+}

--- a/example-f407-board/examples/serial.rs
+++ b/example-f407-board/examples/serial.rs
@@ -1,0 +1,89 @@
+//! CDC-ACM serial port example using polling in a busy loop.
+#![no_std]
+#![no_main]
+
+extern crate panic_semihosting;
+
+use cortex_m_rt::entry;
+use stm32f4xx_hal::{prelude::*, stm32};
+use stm32f4xx_hal::usb::{Peripheral, UsbBus};
+use usb_device::prelude::*;
+use usbd_serial::{SerialPort, USB_CLASS_CDC};
+use embedded_hal::digital::v2::OutputPin;
+
+static mut EP_MEMORY: [u32; 1024] = [0; 1024];
+
+#[entry]
+fn main() -> ! {
+    let dp = stm32::Peripherals::take().unwrap();
+
+    let rcc = dp.RCC.constrain();
+
+    let _clocks = rcc
+        .cfgr
+        .use_hse(8.mhz())
+        .sysclk(48.mhz())
+        .pclk1(24.mhz())
+        .require_pll48clk()
+        .freeze();
+
+    let gpioc = dp.GPIOC.split();
+    let mut led = gpioc.pc13.into_push_pull_output();
+    led.set_high(); // Turn off
+
+
+    let gpioa = dp.GPIOA.split();
+
+    let usb = Peripheral {
+        usb_global: dp.OTG_FS_GLOBAL,
+        usb_device: dp.OTG_FS_DEVICE,
+        usb_pwrclk: dp.OTG_FS_PWRCLK,
+        pin_dm: gpioa.pa11.into_alternate_af10(),
+        pin_dp: gpioa.pa12.into_alternate_af10(),
+    };
+
+    let usb_bus = UsbBus::new(usb, unsafe { &mut EP_MEMORY });
+
+    let mut serial = SerialPort::new(&usb_bus);
+
+    let mut usb_dev = UsbDeviceBuilder::new(&usb_bus, UsbVidPid(0x16c0, 0x27dd))
+        .manufacturer("Fake company")
+        .product("Serial port")
+        .serial_number("TEST")
+        .device_class(USB_CLASS_CDC)
+        .build();
+
+    loop {
+        if !usb_dev.poll(&mut [&mut serial]) {
+            continue;
+        }
+
+        let mut buf = [0u8; 64];
+
+        match serial.read(&mut buf) {
+            Ok(count) if count > 0 => {
+                led.set_low(); // Turn on
+
+                // Echo back in upper case
+                for c in buf[0..count].iter_mut() {
+                    if 0x61 <= *c && *c <= 0x7a {
+                        *c &= !0x20;
+                    }
+                }
+
+                let mut write_offset = 0;
+                while write_offset < count {
+                    match serial.write(&buf[write_offset..count]) {
+                        Ok(len) if len > 0 => {
+                            write_offset += len;
+                        },
+                        _ => {},
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        led.set_high(); // Turn off
+    }
+}

--- a/example-f407-board/examples/test_class.rs
+++ b/example-f407-board/examples/test_class.rs
@@ -1,0 +1,48 @@
+#![no_std]
+#![no_main]
+
+extern crate panic_semihosting;
+
+use cortex_m_rt::entry;
+use stm32f4xx_hal::{prelude::*, stm32};
+use stm32f4xx_hal::usb::{Peripheral, UsbBus};
+use usb_device::test_class::TestClass;
+
+static mut EP_MEMORY: [u32; 1024] = [0; 1024];
+
+#[entry]
+fn main() -> ! {
+    let dp = stm32::Peripherals::take().unwrap();
+
+    let rcc = dp.RCC.constrain();
+
+    let _clocks = rcc
+        .cfgr
+        .use_hse(8.mhz())
+        .sysclk(48.mhz())
+        .pclk1(24.mhz())
+        .require_pll48clk()
+        .freeze();
+
+    let gpioa = dp.GPIOA.split();
+
+    let usb = Peripheral {
+        usb_global: dp.OTG_FS_GLOBAL,
+        usb_device: dp.OTG_FS_DEVICE,
+        usb_pwrclk: dp.OTG_FS_PWRCLK,
+        pin_dm: gpioa.pa11.into_alternate_af10(),
+        pin_dp: gpioa.pa12.into_alternate_af10(),
+    };
+
+    let usb_bus = UsbBus::new(usb, unsafe { &mut EP_MEMORY });
+
+    let mut test = TestClass::new(&usb_bus);
+
+    let mut usb_dev = { test.make_device(&usb_bus) };
+
+    loop {
+        if usb_dev.poll(&mut [&mut test]) {
+            test.poll();
+        }
+    }
+}

--- a/example-f407-board/memory.x
+++ b/example-f407-board/memory.x
@@ -1,0 +1,8 @@
+/* Linker script for building examples for the STM32F407VG */
+MEMORY
+{
+  FLASH : ORIGIN = 0x08000000, LENGTH = 1M
+  RAM : ORIGIN = 0x20000000, LENGTH = 128K
+}
+
+_stack_start = ORIGIN(RAM) + LENGTH(RAM);

--- a/example-f407-board/openocd.cfg
+++ b/example-f407-board/openocd.cfg
@@ -1,0 +1,9 @@
+source [find interface/stlink-v2-1.cfg]
+transport select hla_swd
+
+# increase working area to 64KB
+#set WORKAREASIZE 0x10000
+
+source [find target/stm32f4x.cfg]
+
+reset_config srst_only

--- a/example-f407-board/openocd.gdb
+++ b/example-f407-board/openocd.gdb
@@ -1,0 +1,24 @@
+set history save on
+set confirm off
+target extended-remote :3333
+monitor arm semihosting enable
+monitor reset halt
+
+# print demangled symbols
+set print asm-demangle on
+
+# set backtrace limit to not have infinite backtrace loops
+set backtrace limit 32
+
+# detect unhandled exceptions, hard faults and panics
+break DefaultHandler
+break HardFault
+#break rust_begin_unwind
+
+#break main
+
+load
+continue
+# monitor verify
+# monitor reset
+# quit

--- a/example-f407-board/src/main.rs
+++ b/example-f407-board/src/main.rs
@@ -1,0 +1,50 @@
+#![no_std]
+#![no_main]
+
+extern crate panic_semihosting;
+
+use cortex_m_rt::entry;
+use stm32f4xx_hal::{prelude::*, stm32};
+use stm32f4xx_hal::usb::{Peripheral, UsbBus};
+use usb_device::prelude::*;
+
+static mut EP_MEMORY: [u32; 1024] = [0; 1024];
+
+#[entry]
+fn main() -> ! {
+    let dp = stm32::Peripherals::take().unwrap();
+
+    let rcc = dp.RCC.constrain();
+
+    let _clocks = rcc
+        .cfgr
+        .use_hse(8.mhz())
+        .sysclk(48.mhz())
+        .pclk1(24.mhz())
+        .require_pll48clk()
+        .freeze();
+
+    let gpioa = dp.GPIOA.split();
+
+    let usb = Peripheral {
+        usb_global: dp.OTG_FS_GLOBAL,
+        usb_device: dp.OTG_FS_DEVICE,
+        usb_pwrclk: dp.OTG_FS_PWRCLK,
+        pin_dm: gpioa.pa11.into_alternate_af10(),
+        pin_dp: gpioa.pa12.into_alternate_af10(),
+    };
+
+    let usb_bus = UsbBus::new(usb, unsafe { &mut EP_MEMORY });
+
+    let mut usb_dev = UsbDeviceBuilder::new(&usb_bus, UsbVidPid(0x5824, 0x27dd))
+        .manufacturer("Fake company")
+        .product("Enumeration test")
+        .serial_number("TEST")
+        .device_class(0)
+        .build();
+
+    loop {
+        if usb_dev.poll(&mut []) {
+        }
+    }
+}


### PR DESCRIPTION
This commit adds examples for the stm32f407 discovery board

The usb feature needs to be selected in your fork of the hal fork as well. If you want to I can try to make a pull request against your fork, but it so simple so its probably easier for you to just adding the stm32f407 to the any statement?

Tested on my board
Closes #2 

```
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ pub mod timer;
 pub mod qei;
 #[cfg(all(
     feature = "synopsys-usb-otg",
-    any(feature = "stm32f401", feature = "stm32f429", feature = "stm32f446")
+    any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f429", feature = "stm32f446")
 ))]
 pub mod usb;
```